### PR TITLE
Check for ExecResult error in sandbox

### DIFF
--- a/src/openelm/sandbox/server/index.py
+++ b/src/openelm/sandbox/server/index.py
@@ -2,7 +2,7 @@ from flask import Flask, request
 from numpy import ndarray
 
 from .environments.walker.walk_creator import Walker
-from .sandbox_codex_execute import unsafe_execute
+from .sandbox_codex_execute import unsafe_execute, ExecResult
 
 app = Flask(__name__)
 
@@ -32,9 +32,9 @@ def generate_racer(code_str, timeout):
                 walker=execution_result.to_dict(),
                 unsafe_execute_error_code=1,
             )
-    elif isinstance(execution_result, int):
+    elif isinstance(execution_result, ExecResult):
         return bad_request(
-            "Failed sandbox_unsafe_execute", unsafe_execute_error_code=execution_result
+            "Failed sandbox_unsafe_execute", unsafe_execute_error_code=execution_result.name
         )
     else:
         return bad_request(
@@ -67,10 +67,10 @@ def evaluate_function():
                 "program_str": req_json["code"],
                 "result_obj": execution_result.tolist().__repr__(),
             }, 200
-        elif isinstance(execution_result, int):
+        elif isinstance(execution_result, ExecResult):
             return bad_request(
                 "Failed sandbox_unsafe_execute",
-                unsafe_execute_error_code=execution_result,
+                unsafe_execute_error_code=execution_result.name,
             )
         else:
             bad_request(


### PR DESCRIPTION
Check whether `execution_result` is of type `ExecResult` instead of `int`. An ExecResult is returned when there is an error. Also, there will be valid code executions that return an int such as with programming puzzles.

This is the minimum change necessary with the current code. I'm a little confused on how `ExecResult` is defined in combination with how it's used. The fact that `ExecResult` has a `VALID =  0` might cause a mixup in the future (VALID is currently not used; sidenote: should this be using it https://github.com/CarperAI/OpenELM/blob/v0.2.0/src/openelm/sandbox/server/sandbox_codex_execute.py#L79 ?)

As a result, I see two other ways of doing it if we want to address this now (in either case maybe renaming it):
1. Remove `VALID = 0` and treat ExecResult as an error class
2. Keep VALID but return a tuple of (actual_result=None, ExecResult) such that on successful executions, the actual result is returned and ExecResult conveys that the execution was valid.