### PR TITLE
hotfix for moving galloper demo

### DIFF
--- a/src/openelm/environments/sodaracer/environment_sandbox.py
+++ b/src/openelm/environments/sodaracer/environment_sandbox.py
@@ -1,8 +1,8 @@
 from openelm.environments.sodaracer.box2d_examples.framework import main
 
 from openelm.environments.sodaracer.simulator import IESoRWorld
-from openelm.environments.sodaracer.walker.radial import (
-    make_walker as make_walker_radial,
+from openelm.environments.sodaracer.walker.galloper import (
+    make_walker as make_walker_galloper,
 )
 
 
@@ -11,7 +11,7 @@ class DemoLoadWalkerWorld(IESoRWorld):
     def __init__(self, canvas_size: tuple[int, int] = (150, 200)):
         super().__init__(canvas_size)
         # here we import an example make_walker method, and load it to world
-        self.load_body_into_world(make_walker_radial().to_dict())
+        self.load_body_into_world(make_walker_galloper().to_dict())
 
 
 if __name__ == "__main__":

--- a/src/openelm/environments/sodaracer/walker/walk_creator.py
+++ b/src/openelm/environments/sodaracer/walker/walk_creator.py
@@ -52,7 +52,8 @@ class Walker:
                 return False
         return True
 
-
+# scaling quick fix to make seed programs slightly smaller in scale, potentially making the evolved programs more dynamic
+SCALE = 0.22
 class walker_creator:
     """Walker Creator Referenced in ELM Paper - https://arxiv.org/abs/2206.08896 (pg.16)."""
 
@@ -62,7 +63,8 @@ class walker_creator:
 
     def add_joint(self, x: float, y: float) -> tuple[float, float]:
         """Add a spring/joint to the sodaracer."""
-        j: tuple[float, float] = (x, y)
+        # flipped sign to make galloper move more closely to expected, without functional impact on ELM experiments
+        j: tuple[float, float] = (x*SCALE, -y*SCALE)
         self.joints.append(j)
         return j
 


### PR DESCRIPTION
Small changes, which make galloper demo moving and usable.

Discrepancies seem to only be in the actual walker maker scripts (for demo ELM-discovered ones), so no functional changes to sim foreseen, but still cool if fixed for more demos.