### PR TITLE
bugfix for Map.min with only infinite values

### DIFF
--- a/src/openelm/map_elites.py
+++ b/src/openelm/map_elites.py
@@ -104,17 +104,33 @@ class Map:
 
     @property
     def max(self) -> float:
-        """Returns the maximum value in the map."""
-        return self.array.max()
+        """Returns the maximum value in the map, not including history."""
+        return self.latest.max()
 
     @property
     def min(self) -> float:
-        """Returns the minimum value in the map."""
-        return self.latest[np.isfinite(self.latest)].min()
+        """Returns the minimum value in the map, not including history."""
+        return self.latest.min()
+
+    @property
+    def max_finite(self) -> float:
+        """Returns the maximum finite value in the map, not including history."""
+        if not np.isfinite(self.latest).any():
+            return np.NaN
+        else:
+            return self.latest[np.isfinite(self.latest)].max()
+
+    @property
+    def min_finite(self) -> float:
+        """Returns the minimum finite value in the map, not including history."""
+        if not np.isfinite(self.latest).any():
+            return np.NaN
+        else:
+            return self.latest[np.isfinite(self.latest)].min()
 
     @property
     def mean(self) -> np.ndarray:
-        """Returns the mean value in the map."""
+        """Returns the mean finite value in the map."""
         return np.mean(self.latest[np.isfinite(self.latest)])
 
     @property
@@ -301,7 +317,7 @@ class MAPElitesBase:
 
     def max_fitness(self):
         """Get the maximum fitness value in the map."""
-        return self.fitnesses.max
+        return self.fitnesses.max_finite
 
     def mean_fitness(self):
         """Get the mean fitness value in the map."""
@@ -309,7 +325,7 @@ class MAPElitesBase:
 
     def min_fitness(self):
         """Get the minimum fitness value in the map."""
-        return self.fitnesses.min
+        return self.fitnesses.min_finite
 
     def qd_score(self):
         """

--- a/tests/test_mapelites.py
+++ b/tests/test_mapelites.py
@@ -43,6 +43,7 @@ def test_map():
     fitnesses[1, 2] = -1.
     fitnesses[1, 2] = 2.
     fitnesses[1, 2] = -2.
+    fitnesses[0, 2] = np.inf
 
     assert fitnesses.shape == (4, 3, 3)
     assert fitnesses.top.shape == (3, 3)
@@ -51,6 +52,7 @@ def test_map():
     assert fitnesses.top[2, 2] == 0.
     assert fitnesses.top[1, 2] == 3.
     assert fitnesses.top[2, 1] == 3.
+    assert fitnesses.top[0, 2] == 0.
 
     latest = fitnesses.latest
     assert latest.shape == (3, 3)
@@ -59,10 +61,41 @@ def test_map():
     assert latest[2, 2] == 1.
     assert latest[1, 2] == -2.
     assert latest[2, 1] == -np.inf
+    assert latest[0, 2] == np.inf
 
-    assert fitnesses.min == -2.
-    assert fitnesses.max == 5.
+    assert fitnesses.min == -np.inf
+    assert fitnesses.min_finite == -2.
+    assert fitnesses.max == np.inf
+    assert fitnesses.max_finite == 5.
     assert fitnesses.mean == (-2. + 5 + 1 - 2) / 4
+
+
+def test_empty_map():
+    behavior_ndim = 2
+    map_grid_size = [3]
+    history_length = 4
+    fitnesses = Map(
+        dims=map_grid_size * behavior_ndim,
+        fill_value=-np.inf,
+        dtype=float,
+        history_length=history_length,
+    )
+
+    assert fitnesses.min == -np.inf
+    assert np.isnan(fitnesses.min_finite)
+    assert fitnesses.max == -np.inf
+    assert np.isnan(fitnesses.max_finite)
+
+
+def test_empty_mapelites():
+    target_string = "AAA"
+    env: BaseEnvironment = MatchString(StringEnvConfig(target=target_string, batch_size=1))
+    elites = MAPElites(env, MAPElitesConfig(map_grid_size=(2,), history_length=10))
+    assert elites.fitnesses.min == -np.inf
+    assert np.isnan(elites.fitnesses.min_finite)
+    assert elites.fitnesses.max == -np.inf
+    assert np.isnan(elites.fitnesses.max_finite)
+    # elites.plot_fitness()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
This fixes a bug when calling Map.min when the map only contains infinite values.

Cause:
- a filtering step that removed infinite values before performing min, necessary to get the minimum fitness from visited niches only.

Fix:

- min and max now do not filter out infinite values.
- adds min_finite and max_finite, which perform filtering and return nan if map only contains infinite values.

Note:
- this changes the behaviour of Map.max, which previously found the max value over all values, including historical values. Map.min, Map.max and Map.mean now work similarly, finding the max/min/mean only over the active entries in each niche.
- adds corresponding tests.