### PR TITLE
hotfix qd_score method, fix last hotfix error

### DIFF
--- a/src/openelm/map_elites.py
+++ b/src/openelm/map_elites.py
@@ -101,7 +101,7 @@ class Map:
     @property
     def qd_score(self) -> float:
         """Returns the quality-diversity score of the map."""
-        return self.array[np.isfinite(self.array)].sum()
+        return self.latest[np.isfinite(self.latest)].sum()
 
     @property
     def max(self) -> float:
@@ -336,7 +336,7 @@ class MAPElitesBase:
         The quality-diversity score is the sum of the performance of all solutions
         in the map.
         """
-        return self.fitnesses.latest.qd_score
+        return self.fitnesses.qd_score
 
     def save_results(self):
         output_folder = self.config.output_dir


### PR DESCRIPTION
I made an untested, incorrect hotfix for computing qd_score here: https://github.com/CarperAI/OpenELM/pull/53

These changes can now run when calling qd_score, and is in line with using the `latest` attribute of the (fitnesses) map when computing stats from this.

Apologies for the previous error, hopefully this resolves any inconveniences from before the fix!