### PR TITLE
Prompt evolution

### DIFF
--- a/src/openelm/configs.py
+++ b/src/openelm/configs.py
@@ -37,6 +37,13 @@ class DiffModelConfig(ModelConfig):
 
 
 @dataclass
+class LangChainModelConfig(ModelConfig):
+    model_name: str = "langchain"
+    # model_path: str = "google/flan-t5-xl"
+    model_path: str = "EleutherAI/pythia-1.4b-deduped"
+
+
+@dataclass
 class QDConfig(BaseConfig):
     init_steps: int = 2
     total_steps: int = 5
@@ -106,6 +113,12 @@ class P3EnvConfig(EnvConfig):
     timeout: float = 1.0
 
 
+@dataclass
+class PromptEnvConfig(EnvConfig):
+    env_name: str = "prompt_evolution"
+    evals_per_prompt: int = 1  # TODO
+
+
 defaults_elm = [
     {"model": "prompt"},
     {"qd": "mapelites"},
@@ -165,10 +178,12 @@ def register_configstore() -> ConfigStore:
     cs.store(group="env", name="image_evolution", node=ImageEnvConfig)
     cs.store(group="env", name="string_evolution", node=StringEnvConfig)
     cs.store(group="env", name="p3_problem", node=P3EnvConfig)
+    cs.store(group="env", name="prompt_evolution", node=PromptEnvConfig)
     cs.store(group="qd", name="mapelites", node=MAPElitesConfig)
     cs.store(group="qd", name="cvtmapelites", node=CVTMAPElitesConfig)
     cs.store(group="model", name="prompt", node=PromptModelConfig)
     cs.store(group="model", name="diff", node=DiffModelConfig)
+    cs.store(group="model", name="langchain", node=LangChainModelConfig)
     cs.store(name="elmconfig", node=ELMConfig)
     cs.store(name="p3config", node=P3Config)
     return cs

--- a/src/openelm/elm.py
+++ b/src/openelm/elm.py
@@ -2,9 +2,19 @@ from typing import Optional
 
 from hydra.core.hydra_config import HydraConfig
 
-from openelm.configs import DiffModelConfig, ELMConfig, PromptModelConfig
+from openelm.configs import (
+    DiffModelConfig,
+    ELMConfig,
+    LangChainModelConfig,
+    PromptModelConfig,
+)
 from openelm.environments import ENVS_DICT, QD_DICT
-from openelm.mutation_model import DiffModel, MutationModel, PromptModel
+from openelm.mutation_model import (
+    DiffModel,
+    LangChainPromptModel,
+    MutationModel,
+    PromptModel,
+)
 
 
 class ELM:
@@ -25,7 +35,11 @@ class ELM:
         if isinstance(self.config.model, PromptModelConfig):
             self.mutation_model: MutationModel = PromptModel(self.config.model)
         elif isinstance(self.config.model, DiffModelConfig):
-            self.mutation_model = DiffModel(self.config.model)
+            self.mutation_model: MutationModel = DiffModel(self.config.model)
+        elif isinstance(self.config.model, LangChainModelConfig):
+            self.mutation_model: MutationModel = LangChainPromptModel(
+                config=self.config.model
+            )
 
         self.environment = ENVS_DICT[env_name](
             config=self.config.env,

--- a/src/openelm/environments/__init__.py
+++ b/src/openelm/environments/__init__.py
@@ -7,6 +7,7 @@ from openelm.environments.environments import (
     ImageOptim,
     MatchString,
     P3Problem,
+    PromptEvolution,
     Sodarace,
 )
 from openelm.map_elites import CVTMAPElites, MAPElites
@@ -124,6 +125,7 @@ ENVS_DICT: dict[str, Any] = {
     "sodarace": Sodarace,
     "image_evolution": ImageOptim,
     "p3": P3Problem,
+    "prompt_evolution": PromptEvolution,
 }
 
 QD_DICT: dict[str, Any] = {

--- a/src/openelm/environments/env_utils.py
+++ b/src/openelm/environments/env_utils.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import numpy as np
 
 
@@ -23,3 +25,37 @@ def draw():
 """
 
 NULL_SEED: str = ""
+
+
+@dataclass
+class ToyPromptTask:
+    base_template = "{few_shot_examples}\n{instruction_str} the word {target} {n_repetitions} times:"
+    input_variables = [
+        "few_shot_examples",
+        "target",
+        "instruction_str",
+        "n_repetitions",
+    ]
+
+    target = "hello"
+    instruction_str = "Repeat"
+
+    mutation_instruction = """Q: What is a synonym for happy?
+A: Cheerful
+
+Q: What is a synonym for sad?
+A: Melancholy
+
+Q: What is a synonym for alter?
+A: Adjust
+
+Q: What is a synonym for finish?
+A: End
+
+Q: What is a synonym for {instruction_str}?
+A:"""
+
+    def create_few_shot_examples(self, instruction_str):
+        return f"""{instruction_str} the word {self.target} 2 times: {self.target} {self.target}
+{instruction_str} the word {self.target} 3 times: {self.target} {self.target} {self.target}
+{instruction_str} the word {self.target} 4 times: {self.target} {self.target} {self.target} {self.target}"""

--- a/src/openelm/environments/environments.py
+++ b/src/openelm/environments/environments.py
@@ -8,15 +8,18 @@ from typing import Generic, Optional, Type, TypeVar, Union
 
 import numpy as np
 import requests
+from langchain import PromptTemplate
+from langchain.chains import LLMChain
 
 from openelm.configs import (
     EnvConfig,
     ImageEnvConfig,
     P3EnvConfig,
+    PromptEnvConfig,
     SodaraceEnvConfig,
     StringEnvConfig,
 )
-from openelm.environments.env_utils import NULL_SEED, get_image_target
+from openelm.environments.env_utils import NULL_SEED, ToyPromptTask, get_image_target
 from openelm.environments.sodaracer import (
     CIRCLE,
     GALLOPER_PREREQ,
@@ -180,6 +183,126 @@ class MatchString(BaseEnvironment[StringArrayGenotype]):
 
     def fitness(self, x: StringArrayGenotype) -> float:
         return -np.abs(x.to_phenotype() - self.target).sum()
+
+
+class PromptGenotype(Genotype):
+    """
+    Genotype wrapper for a LangChain template.
+
+    This consists of a base format for all individuals, as well as individual-specific fields which will be evolved.
+    Remaining fields will be filled in at evaluation time.
+
+    Args:
+        prompt (PromptTemplate): The base template for all individuals.
+        fixed_inputs (dict[str, str], optional): Individual-specific fields to fill in. Defaults to None.
+    """
+
+    def __init__(self, prompt: PromptTemplate, fixed_inputs: dict[str, str] = None):
+        self.fixed_inputs = fixed_inputs
+        if fixed_inputs:
+            self.prompt = prompt.partial(**fixed_inputs)
+        else:
+            self.prompt = prompt
+        self.result_obj = None
+
+    def __str__(self) -> str:
+        return self.prompt.template
+
+    def format(self, **kwargs) -> str:
+        return self.prompt.format(**kwargs)
+
+    def evaluate(self, model, inputs):
+        chain = LLMChain(llm=model, prompt=self.prompt)
+        self.result_obj = {
+            "prompt": self.format(**inputs),
+            "output": chain(inputs),
+        }
+        return self.result_obj["output"]
+
+    def to_phenotype(self) -> str:
+        return (0.0,)
+
+
+class PromptEvolution(BaseEnvironment[PromptGenotype]):
+    """Evolves a LangChain prompt."""
+
+    def __init__(
+        self,
+        config: PromptEnvConfig,
+        mutation_model: MutationModel,
+        fitness_model=None,
+    ):
+        self.config: PromptEnvConfig = config
+        self.batch_size = self.config.batch_size
+        self.genotype_ndim = 1
+        self.genotype_space = np.array([[0], [1]])
+        self.mutation_model = mutation_model
+        if fitness_model is None:
+            self.fitness_model = mutation_model
+        self.task = ToyPromptTask()
+        self.base_prompt = PromptTemplate(
+            template=self.task.base_template, input_variables=self.task.input_variables
+        )
+
+    def random(self) -> list[PromptGenotype]:
+        return [self.random_prompt() for _ in range(self.batch_size)]
+
+    def random_prompt(self):
+        inputs = {
+            "n_repetitions": str(np.random.randint(10)),
+            "instruction_str": self.task.instruction_str,
+            "few_shot_examples": self.task.create_few_shot_examples(
+                self.task.instruction_str
+            ),
+        }
+        return PromptGenotype(prompt=self.base_prompt, fixed_inputs=inputs)
+
+    def mutate(self, genomes: list[PromptGenotype]) -> list[PromptGenotype]:
+        prompts = [self.mutate_prompt(prompt) for prompt in genomes]
+        return prompts
+
+    def mutate_prompt(self, prompt):
+        # mutate the instruction string; note that we also need to change the few shot examples to match
+        old_instruction_str = prompt.fixed_inputs["instruction_str"]
+        mutation_prompt = PromptTemplate(
+            input_variables=["instruction_str"],
+            template=self.task.mutation_instruction,
+        )
+        mutation_chain = LLMChain(llm=self.fitness_model, prompt=mutation_prompt)
+        result = mutation_chain({"instruction_str": old_instruction_str})
+        new_instruction_str = result["text"].strip().split()[0]
+
+        inputs = {
+            "n_repetitions": str(np.random.randint(10)),
+            "instruction_str": new_instruction_str,
+            "few_shot_examples": self.task.create_few_shot_examples(
+                new_instruction_str
+            ),
+        }
+
+        return PromptGenotype(prompt=self.base_prompt, fixed_inputs=inputs)
+
+    def fitness(self, x: PromptGenotype) -> float:
+        inputs = {
+            "target": self.task.target,
+        }
+        result = x.evaluate(model=self.fitness_model, inputs=inputs)
+        # chain = LLMChain(llm=self.fitness_model, prompt=x.prompt)
+        # result = chain({"target":self.task.target})
+
+        # fitness is number of times it generated the target word in a row
+        count = 0
+        for word in result["text"].strip().split():
+            if word.lower() == self.task.target:
+                count += 1
+            else:
+                break
+
+        fitness = count
+        if self.config.debug:
+            print(f"-- Prompt --\n{x.result_obj['prompt']}\n-- Fitness: {fitness} --")
+
+        return fitness
 
 
 class ImageGeneration(Genotype):
@@ -432,22 +555,21 @@ class Sodarace(BaseEnvironment[Sodaracer]):
         """
         Constructs a prompt for generating Sodaracers.
 
-        Parameters:
-            code_batch (Optional[Union[list[str], str]], optional): A 
+        Args:
+            code_batch (Optional[Union[list[str], str]], optional): A
             list of program strings or a single program string. Defaults to None.
 
         Returns:
-            dict[str, str]: A dictionary containing two keys: "prompt" and 
-            "template". The "prompt" key maps to a string containing the 
+            dict[str, str]: A dictionary containing two keys: "prompt" and
+            "template". The "prompt" key maps to a string containing the
             full prompt for generating a Sodaracer program. The "template"
-            key maps to a string containing the required imports and 
+            key maps to a string containing the required imports and
             instruction for generating a Sodaracer program.
 
         The method constructs a prompt for generating Sodaracer programs
-        based on the seeds and configuration settings specified in self.seed_strs 
-        and self.config. 
+        based on the seeds and configuration settings specified in self.seed_strs
+        and self.config.
         """
-
         prompt_str: str = IMPORTS
         if "square" in self.seed_strs:
             prompt_str += SQUARE_PREREQ
@@ -509,8 +631,10 @@ class Sodarace(BaseEnvironment[Sodaracer]):
     def generate_programs(self, code_batch: list[dict[str, str]]) -> list[Sodaracer]:
         """
         Generate new programs with a mutation model and evaluate them.
+
         Args:
             code_batch (list[dict[str, str]): a list of program strings.
+
         Returns:
             list[Sodaracer]: A list of Sodaracer objects.
         """
@@ -560,19 +684,22 @@ class Sodarace(BaseEnvironment[Sodaracer]):
     def random(self) -> list[Sodaracer]:
         """
         Generates a batch of Sodaracer programs with the specified batch size.
+
         Returns a list of new Sodaracer programs.
+
         Returns:
             list[Sodaracer]: A list of random Sodaracer programs.
         """
-
         program_list = [self.construct_prompt() for _ in range(self.config.batch_size)]
         new_sodaracers = self.generate_programs(program_list)
         return new_sodaracers
 
     def mutate(self, sodaracer_list: list[Sodaracer]) -> list[Sodaracer]:
         """
-        Given a list of Sodaracer programs, constructs a prompt for each program, 
-        generate a list of new programs by mutating the prompts, and returns a 
+        Mutates a list of Sodaracer programs.
+
+        Given a list of Sodaracer programs, constructs a prompt for each program,
+        generate a list of new programs by mutating the prompts, and returns a
         list of new Sodaracer programs.
 
         Args:
@@ -581,7 +708,6 @@ class Sodarace(BaseEnvironment[Sodaracer]):
         Returns:
             list[Sodaracer]: A list of new Sodaracer programs generated by mutating the prompts.
         """
-
         sodaracers = [sr.program_str for sr in sodaracer_list]
         program_list = list(map(self.construct_prompt, sodaracers))
         new_sodaracers = self.generate_programs(program_list)
@@ -597,11 +723,10 @@ class Sodarace(BaseEnvironment[Sodaracer]):
         Returns:
             float: fitness of the Sodaracer.
 
-        The method first checks whether the Sodaracer program is valid or not using 
-        the `.evaluate()` method of the Sodaracer. If the program is invalid, 
+        The method first checks whether the Sodaracer program is valid or not using
+        the `.evaluate()` method of the Sodaracer. If the program is invalid,
         the method returns -np.inf to indicate that the program is not fit.
         """
-
         if x.valid:
             return x.evaluate(self.config.eval_ms)
         else:

--- a/src/openelm/environments/environments.py
+++ b/src/openelm/environments/environments.py
@@ -287,8 +287,6 @@ class PromptEvolution(BaseEnvironment[PromptGenotype]):
             "target": self.task.target,
         }
         result = x.evaluate(model=self.fitness_model, inputs=inputs)
-        # chain = LLMChain(llm=self.fitness_model, prompt=x.prompt)
-        # result = chain({"target":self.task.target})
 
         # fitness is number of times it generated the target word in a row
         count = 0


### PR DESCRIPTION
This adds the prompt evolution environment. This allows us to evolve general templates for prompts with values that can be filled in later (e.g. during fitness evaluation).

- Adds classes for genotype and environment
- Adds a langchain wrapper for HF models
- Adds support for seq2seq models (FLAN-T5)

Also includes a toy task for evolving a prompt that generates repeated words (e.g. "Repeat the word hello 10 times") that showcases a few things we can do with a template:
- LM mutation on the instruction string ("repeat") and random mutation on the numerical value (10)
- individuals generate their own few-shot examples based on their instruction
- "hello" is filled in at evaluation time, so we can test prompts on datasets or dynamic tasks

Notes/todo
- LM is bad at counting words, so this is not necessarily the best task for a demo
- I'm not sure if the tokenizer/generation is set up optimally for seq2seq - could use a second pair of eyes on this
- behaviour space for the toy task is not defined yet