### PR TITLE
hotfix for blank snapshot_dir and get_rng_state/set_rng_state in prompt evolution

### DIFF
--- a/src/openelm/map_elites.py
+++ b/src/openelm/map_elites.py
@@ -239,7 +239,7 @@ class MAPElitesBase:
         self.nonzero: Map = Map(dims=self.map_dims, fill_value=False, dtype=bool)
 
         log_path = Path(log_snapshot_dir)
-        if os.path.isdir(log_path):
+        if log_snapshot_dir and os.path.isdir(log_path):
             stem_dir = log_path.stem
 
             assert (


### PR DESCRIPTION
Fixes a bug with blank log_snapshot_dir in MAPElitesBase._init_maps()
Also moves get_rng_state and set_rng_state from PromptGenotype to the PromptEvolution environment
Updates PromptEvolution for the new model wrapper