### PR TITLE
check python version for set_int_max_str_digits()

### DIFF
--- a/src/openelm/environments/environments.py
+++ b/src/openelm/environments/environments.py
@@ -24,8 +24,9 @@ from openelm.environments.sodaracer import (
 from openelm.mutation_model import MutationModel
 from openelm.utils.code_eval import pool_exec_processes, type_check
 
-sys.set_int_max_str_digits(0)  # remove length limitation for int->str conversion
-# (model sometimes outputs really long ints)
+if sys.version_info >= (3, 11): # set_int_max_str_digits() new in python 3.11
+  sys.set_int_max_str_digits(0)  # remove length limitation for int->str conversion
+  # (model sometimes outputs really long ints)
 
 Phenotype = Optional[np.ndarray]
 


### PR DESCRIPTION
nmmo is mainly based on python 3.9 and 3.10, and `sys.set_int_max_str_digits()` was introduced in 3.11