### PR TITLE
Allow env class to be passed

### DIFF
--- a/src/openelm/elm.py
+++ b/src/openelm/elm.py
@@ -1,12 +1,13 @@
-from typing import Any, Optional
+from typing import Any, Optional, Type
 
 from hydra.core.hydra_config import HydraConfig
 
 from openelm.configs import DiffModelConfig, ELMConfig, PromptModelConfig
 from openelm.mutation_model import DiffModel, MutationModel, PromptModel
+from openelm.environments.base import BaseEnvironment
 
 
-def load_env(env_name: str) -> Any:
+def load_env(env_name: str) -> Type[BaseEnvironment]:
     if env_name == "sodarace":
         from openelm.environments.sodaracer.sodarace import Sodarace
 
@@ -80,8 +81,15 @@ class ELM:
                 config=self.config.env,
                 mutation_model=self.mutation_model,
             )
-        else:
+        elif isinstance(env, type(BaseEnvironment)):
+            self.environment = env(
+                config=self.config.env,
+                mutation_model=self.mutation_model,
+            )
+        elif isinstance(env, BaseEnvironment):
             self.environment = env
+        else:
+            raise ValueError(f"Unknown environment {env.__name__}")
         self.qd_algorithm = load_algorithm(qd_name)(
             env=self.environment,
             config=self.config.qd,


### PR DESCRIPTION
Previously, if I add NMMOEnvironment to `ENVS_DICT`, the env was initialized with the correct config and mutation model inside the `elm.py`. 

However, after the refactor, the `Elm` class can only accept the envs already defined in `load_env` or the externally instantiated env. When using the externally instantiated env, one also has to provide the externally instantiated model like below, otherwise, `self.mutation_model` in `Elm` won't be linked to the env's mutation model.

```python
        mutation_model = PromptModel(self.config.model)
        elm = ELM(self.config,
                  env=NMMOEnvironment(config=self.config.env,
                                      mutation_model=mutation_model)
        )
        elm.mutation_model = mutation_model
```